### PR TITLE
feat: Complete feed terminology migration and add get_feed_config operation

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -60,60 +60,69 @@ class SubmissionWithCommentsResult(BaseModel):
 Comment.model_rebuild()
 
 
-# Watchlist API Models
+# Feed API Models
 
-class WatchlistAnalysis(BaseModel):
-    """Analysis data for watchlist."""
+class FeedAnalysis(BaseModel):
+    """Analysis data for feed."""
     description: str = Field(..., min_length=10, max_length=1000)
     audience_personas: List[str] = Field(..., min_length=1, max_length=10)
     keywords: List[str] = Field(..., min_length=1, max_length=50)
 
 
 class SubredditOption(BaseModel):
-    """Subreddit option for watchlist."""
+    """Subreddit option for feed."""
     name: str = Field(..., min_length=1, max_length=100)
     description: str = Field(..., max_length=1000)
     subscribers: int = Field(..., ge=0)
     confidence_score: float = Field(..., ge=0.0, le=1.0)
 
 
-class WatchlistCreate(BaseModel):
-    """Request model for creating a watchlist."""
+class FeedCreate(BaseModel):
+    """Request model for creating a feed."""
     name: str = Field(..., min_length=1, max_length=255)
     website_url: Optional[str] = None
-    analysis: Optional[WatchlistAnalysis] = None
+    analysis: Optional[FeedAnalysis] = None
     selected_subreddits: List[SubredditOption] = Field(..., min_length=1)
 
 
-class WatchlistUpdate(BaseModel):
-    """Request model for updating a watchlist (all fields optional)."""
+class FeedUpdate(BaseModel):
+    """Request model for updating a feed (all fields optional)."""
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     website_url: Optional[str] = None
-    analysis: Optional[WatchlistAnalysis] = None
+    analysis: Optional[FeedAnalysis] = None
     selected_subreddits: Optional[List[SubredditOption]] = Field(None, min_length=1)
 
 
-class Watchlist(BaseModel):
-    """Response model for a watchlist."""
+class Feed(BaseModel):
+    """Response model for a feed."""
     id: str
     user_id: str
     name: str
     website_url: Optional[str] = None
-    analysis: Optional[WatchlistAnalysis] = None
+    analysis: Optional[FeedAnalysis] = None
     selected_subreddits: List[SubredditOption]
     created_at: datetime
     updated_at: datetime
 
 
-class WatchlistListResponse(BaseModel):
-    """Response model for listing watchlists."""
-    watchlists: List[Watchlist]
+class FeedListResponse(BaseModel):
+    """Response model for listing feeds."""
+    feeds: List[Feed]
     total: int
     limit: int
     offset: int
 
 
-class WatchlistDeleteResponse(BaseModel):
-    """Response model for deleting a watchlist."""
+class FeedDeleteResponse(BaseModel):
+    """Response model for deleting a feed."""
     success: bool
     message: str
+
+
+class FeedConfig(BaseModel):
+    """Response model for feed configuration."""
+    profile_id: str
+    profile_name: str
+    subreddits: List[str]
+    show_nsfw: bool
+    has_subreddits: bool

--- a/src/server.py
+++ b/src/server.py
@@ -25,6 +25,7 @@ from src.tools.feed import (
     create_feed,
     list_feeds,
     get_feed,
+    get_feed_config,
     update_feed,
     delete_feed,
 )
@@ -166,6 +167,7 @@ def discover_operations(ctx: Context) -> Dict[str, Any]:
             "create_feed": "Create a new feed with analysis and subreddits",
             "list_feeds": "List all feeds for the authenticated user",
             "get_feed": "Get a specific feed by ID",
+            "get_feed_config": "Get feed configuration with subreddit names",
             "update_feed": "Update an existing feed",
             "delete_feed": "Delete a feed"
         },
@@ -495,6 +497,26 @@ def get_operation_schema(
                 {"feed_id": "550e8400-e29b-41d4-a716-446655440000"}
             ]
         },
+        "get_feed_config": {
+            "description": "Get configuration for a feed (subreddit names, settings)",
+            "parameters": {
+                "feed_id": {
+                    "type": "string",
+                    "required": True,
+                    "description": "UUID of the feed to get config for"
+                }
+            },
+            "returns": {
+                "profile_id": "UUID of the feed",
+                "profile_name": "Name of the feed",
+                "subreddits": "Array of subreddit names (strings)",
+                "show_nsfw": "Whether NSFW content is enabled",
+                "has_subreddits": "Whether feed has any subreddits configured"
+            },
+            "examples": [] if not include_examples else [
+                {"feed_id": "550e8400-e29b-41d4-a716-446655440000"}
+            ]
+        },
         "update_feed": {
             "description": "Update an existing feed (partial update - only include fields to change)",
             "parameters": {
@@ -598,6 +620,7 @@ async def execute_operation(
         "create_feed": create_feed,
         "list_feeds": list_feeds,
         "get_feed": get_feed,
+        "get_feed_config": get_feed_config,
         "update_feed": update_feed,
         "delete_feed": delete_feed
     }
@@ -620,7 +643,7 @@ async def execute_operation(
         async_operations = [
             "discover_subreddits", "fetch_multiple", "fetch_comments",
             "create_feed", "list_feeds",
-            "get_feed", "update_feed", "delete_feed"
+            "get_feed", "get_feed_config", "update_feed", "delete_feed"
         ]
         if operation_id in async_operations:
             result = await operations[operation_id](**params)

--- a/src/tools/feed.py
+++ b/src/tools/feed.py
@@ -350,3 +350,57 @@ async def delete_feed(
                 "error": f"Request failed: {str(e)}",
                 "suggestion": "Check that AUDIENCE_API_URL is correctly configured"
             }
+
+
+async def get_feed_config(
+    feed_id: str,
+    ctx: Context = None
+) -> Dict[str, Any]:
+    """
+    Get configuration for a feed.
+
+    Args:
+        feed_id: UUID of the feed to get config for
+        ctx: FastMCP context (optional)
+
+    Returns:
+        Feed configuration with subreddit names
+    """
+    base_url = get_api_base_url()
+    auth_headers = get_auth_headers()
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            response = await client.get(
+                f"{base_url}/feeds/{feed_id}/config",
+                headers=auth_headers
+            )
+
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 401:
+                return {
+                    "error": "Authentication required",
+                    "suggestion": "Ensure you are authenticated with valid Descope credentials"
+                }
+            elif response.status_code == 404:
+                return {
+                    "error": f"Feed not found: {feed_id}",
+                    "suggestion": "Use list_feeds to see available feeds"
+                }
+            else:
+                return {
+                    "error": f"API error: {response.status_code}",
+                    "details": response.text
+                }
+
+        except httpx.TimeoutException:
+            return {
+                "error": "Request timeout",
+                "suggestion": "The API server may be unavailable. Try again later."
+            }
+        except httpx.RequestError as e:
+            return {
+                "error": f"Request failed: {str(e)}",
+                "suggestion": "Check that AUDIENCE_API_URL is correctly configured"
+            }


### PR DESCRIPTION
## Summary
- Rename all `Watchlist*` type models to `Feed*` in `models.py` for terminology consistency with frontend API
- Add new `FeedConfig` model for config endpoint response
- Add `get_feed_config()` async function to retrieve feed configuration via `GET /api/feeds/{feed_id}/config`
- Wire up `get_feed_config` operation in `server.py` (discover, schema, execute)

Aligns MCP server with frontend Feed API refactor.

## Test plan
- [ ] Verify `discover_operations()` shows `get_feed_config` in operations list
- [ ] Verify `get_operation_schema("get_feed_config")` returns correct parameter and return documentation
- [ ] Verify `execute_operation("get_feed_config", {"feed_id": "<valid-uuid>"})` returns config data from frontend API

🤖 Generated with [Claude Code](https://claude.com/claude-code)