### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,8 @@ This project uses:
 [Dialog App](https://app.dialog.tools) | [GitHub](https://github.com/king-of-the-grackles/reddit-research-mcp) | [Report Issues](https://github.com/king-of-the-grackles/reddit-research-mcp/issues)
 
 </div>
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/king-of-the-grackles-reddit-research-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/king-of-the-grackles-reddit-research-mcp).