### PR TITLE
docs(schema): fetch_comments guidance prefers url over submission_id

### DIFF
--- a/src/resources.py
+++ b/src/resources.py
@@ -176,7 +176,7 @@ def register_resources(mcp, reddit: praw.Reddit) -> None:
                         "4. get_operation_schema('fetch_multiple') - Get batch fetch requirements",
                         "5. execute_operation('fetch_multiple', {'subreddit_names': [...], 'limit_per_subreddit': 10})",
                         "6. get_operation_schema('fetch_comments') - Get comment requirements",
-                        "7. execute_operation('fetch_comments', {'submission_id': 'abc123', 'comment_limit': 100})"
+                        "7. execute_operation('fetch_comments', {'url': 'https://reddit.com/r/Python/comments/abc123/', 'comment_limit': 100})"
                     ]
                 },
                 "targeted_search": {

--- a/src/server.py
+++ b/src/server.py
@@ -498,15 +498,16 @@ def get_operation_schema(
         "fetch_comments": {
             "description": "Get complete comment tree for a post",
             "parameters": {
-                "submission_id": {
-                    "type": "string",
-                    "required_one_of": ["submission_id", "url"],
-                    "description": "Reddit post ID (e.g., '1abc234')"
-                },
                 "url": {
                     "type": "string",
                     "required_one_of": ["submission_id", "url"],
-                    "description": "Full Reddit URL to the post"
+                    "description": "Full Reddit URL to the post",
+                    "tip": "Prefer url over submission_id — activity feeds show the subreddit from the url (e.g. 'Reading r/Python discussion')"
+                },
+                "submission_id": {
+                    "type": "string",
+                    "required_one_of": ["submission_id", "url"],
+                    "description": "Reddit post ID (e.g., '1abc234'); use only when no url is available"
                 },
                 "comment_limit": {
                     "type": "integer",
@@ -522,8 +523,8 @@ def get_operation_schema(
                 }
             },
             "examples": [] if not include_examples else [
-                {"submission_id": "1abc234", "comment_limit": 100},
-                {"url": "https://reddit.com/r/Python/comments/xyz789/", "comment_limit": 50, "comment_sort": "top"}
+                {"url": "https://reddit.com/r/Python/comments/xyz789/", "comment_limit": 50, "comment_sort": "top"},
+                {"submission_id": "1abc234", "comment_limit": 100}
             ]
         },
         "create_feed": {
@@ -837,7 +838,7 @@ execute_operation("fetch_multiple", {{
 ### PHASE 4: DEEP DIVE INTO DISCUSSIONS
 For posts with high engagement (10+ comments, 5+ upvotes):
 execute_operation("fetch_comments", {{
-    "submission_id": "<post_id>",
+    "url": "<post_url>",
     "comment_limit": 100,
     "comment_sort": "best"
 }})


### PR DESCRIPTION
## Why
The Dialog app's activity feed can only show which subreddit a `fetch_comments` call is reading when the call carries the post **url** — the subreddit is in the url path (`reddit.com/r/Python/comments/…`), while a bare `submission_id` reveals nothing. The schema, the research prompt template, and the workflow examples all taught `submission_id` first, so models overwhelmingly passed ids and every comment fetch rendered as a generic "Reading discussion".

Companion to frontend-reddit-research-mcp#435, which parses the subreddit out of the url for the label.

## Changes (guidance only — no behavior change)
- `get_operation_schema('fetch_comments')`: `url` listed first with a tip explaining the preference; `submission_id` described as the no-url fallback; url example moved first.
- Research prompt Phase 4 template and the `deep_analysis` workflow steps now demonstrate `url`.

Both parameters remain accepted (`required_one_of` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)